### PR TITLE
Fix task status and priority enums

### DIFF
--- a/karton/dashboard/templates/task.html
+++ b/karton/dashboard/templates/task.html
@@ -5,9 +5,9 @@
 
   <dl class="row">
     <dt class="col-3">Status</dt>
-    <dd class="col-9"><span class="badge badge-light">{{task.status}}</span></dd>
+    <dd class="col-9"><span class="badge badge-light">{{task.status.value}}</span></dd>
     <dt class="col-3">Priority</dt>
-    <dd class="col-9"><span class="badge badge-dark">{{task.priority}}</span></dd>
+    <dd class="col-9"><span class="badge badge-dark">{{task.priority.value}}</span></dd>
     <dt class="col-3">Last status change</dt>
     <dd class="col-9">{{task.last_update}} ({{task.last_update_delta}})</dd>
     <dt class="col-3">UID</dt>


### PR DESCRIPTION
Task status and priority are enums, so we should display them as such