### PR TITLE
Sort tasks and queues before presenting

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -88,6 +88,9 @@ class QueueView:
         self._queue = queue
 
     def to_dict(self) -> Dict[str, Any]:
+        tasks = [task.uid for task in self._queue.pending_tasks]
+        crashed = [task.uid for task in self._queue.crashed_tasks]
+
         return {
             "identity": self._queue.bind.identity,
             "filters": self._queue.bind.filters,
@@ -95,8 +98,8 @@ class QueueView:
             "persistent": self._queue.bind.persistent,
             "version": self._queue.bind.version,
             "replicas": self._queue.online_consumers_count,
-            "tasks": [task.uid for task in self._queue.pending_tasks],
-            "crashed": [task.uid for task in self._queue.crashed_tasks],
+            "tasks": sorted(tasks, key=lambda t: t.last_update, reverse=True),
+            "crashed": sorted(crashed, key=lambda t: t.last_update, reverse=True),
         }
 
 

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -18,10 +18,10 @@ from flask import (  # type: ignore
     request,
     send_from_directory,
 )
-from karton.core import Producer  # type: ignore
-from karton.core.base import KartonBase  # type: ignore
-from karton.core.inspect import KartonAnalysis, KartonQueue, KartonState  # type: ignore
-from karton.core.task import Task, TaskState  # type: ignore
+from karton.core import Producer
+from karton.core.base import KartonBase
+from karton.core.inspect import KartonAnalysis, KartonQueue, KartonState
+from karton.core.task import Task, TaskPriority, TaskState
 from mworks import CommonRoutes  # type: ignore
 from prometheus_client import Gauge, generate_latest  # type: ignore
 
@@ -61,11 +61,11 @@ class TaskView:
         return self._task.root_uid
 
     @property
-    def priority(self) -> str:
+    def priority(self) -> TaskPriority:
         return self._task.priority
 
     @property
-    def status(self) -> str:
+    def status(self) -> TaskState:
         return self._task.status
 
     @property

--- a/karton/dashboard/templates/crashed.html
+++ b/karton/dashboard/templates/crashed.html
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for task in queue.crashed_tasks %}
+    {% for task in queue.crashed_tasks|sort(attribute='last_update', reverse=True) %}
     <tr>
       <td>
         <a href="/task/{{ task.uid }}">{{ task.uid }}</a>

--- a/karton/dashboard/templates/index.html
+++ b/karton/dashboard/templates/index.html
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for (queue_name, queue) in queues.items() %}
+      {% for (queue_name, queue) in queues|dictsort %}
       <tr>
         <td>
           <a href="queue/{{ queue_name }}">{{ queue_name }}</a>

--- a/karton/dashboard/templates/queue.html
+++ b/karton/dashboard/templates/queue.html
@@ -9,7 +9,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for task in queue.pending_tasks %}
+    {% for task in queue.pending_tasks|sort(attribute='last_update', reverse=True) %}
     <tr>
       <td>
         <a href="/task/{{task.uid}}">{{ task.uid }}</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.1
-karton-core==4.0.4
+karton-core==4.0.5
 mworks==2.0.0
 mistune==0.8.4
 prometheus_client==0.9.0


### PR DESCRIPTION
Right now it behaves pretty non-deterministically, which probably isn't the expected behavior.

This PR introduces task & queue sorting (by `last_update` and `name` respectively).
It also bumps karton-core to the newest versions and fixes a small resulting typing error.