### PR TITLE
remove mworks

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -22,7 +22,6 @@ from karton.core import Producer
 from karton.core.base import KartonBase
 from karton.core.inspect import KartonAnalysis, KartonQueue, KartonState
 from karton.core.task import Task, TaskPriority, TaskState
-from mworks import CommonRoutes  # type: ignore
 from prometheus_client import Gauge, generate_latest  # type: ignore
 
 logging.basicConfig(level=logging.INFO)
@@ -30,7 +29,6 @@ logging.basicConfig(level=logging.INFO)
 app_path = Path(__file__).parent
 static_folder = app_path / "static"
 app = Flask(__name__, static_folder=None, template_folder=str(app_path / "templates"))
-mworks = CommonRoutes(app)
 
 karton = KartonBase(identity="karton.dashboard")
 

--- a/karton/dashboard/templates/layout.html
+++ b/karton/dashboard/templates/layout.html
@@ -19,14 +19,6 @@
                         <a class="nav-link" href="/">home</a>
                     </li>
                 </ul>
-                <ul class="nav navbar-nav ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/docz/">help</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/logz">logs</a>
-                    </li>
-                </ul>
             </div>
         </div>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask==1.1.1
 karton-core==4.0.5
-mworks==2.0.0
 mistune==0.8.4
 prometheus_client==0.9.0


### PR DESCRIPTION
This PR removes mworks, as it is (at least for now?) closed source project. I've moved relevant code to karton-dashboard project.

This also removes navbar, as it only contains 1 button (link to `/logz`). With removal of navbar karton-dashboard can be easily embedded in other applications using karton framework. Thihs reduces complexity of applications, as they can simply iframe into karton-dashboard (nvabar doesn't look good there) instead of having a reverse proxy and 2 separate applications.

I believe everyone will agree with first change, but the second one will probably need some discussion.