### PR TITLE
Update server running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then install karton-dashboard from PyPi:
 ```shell
 $ pip install karton-dashboard
 
-$ karton-dashboard
+$ karton-dashboard run -h 127.0.0.1 -p 5000
 ```
 
 ![Co-financed by the Connecting Europe Facility by of the European Union](https://www.cert.pl/wp-content/uploads/2019/02/en_horizontal_cef_logo-1.png)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ $ pip install karton-dashboard
 $ karton-dashboard run -h 127.0.0.1 -p 5000
 ```
 
-The `karton-dashboard` is just a wrapper on the `flask` program so you're free to provide it with arguments accepted by flask like `-h`, `--cert=path` and so on.
+The `karton-dashboard` is just a wrapper on the `flask` program, and it works with any arguments accepted by flask. For example `karton-dashboard --help`, or `karton-dashboard run -h 0.0.0.0 -p 1234`. See [flask documentation](https://flask.palletsprojects.com/en/1.1.x/cli/) for more information.
 
 ![Co-financed by the Connecting Europe Facility by of the European Union](https://www.cert.pl/wp-content/uploads/2019/02/en_horizontal_cef_logo-1.png)

--- a/README.md
+++ b/README.md
@@ -20,4 +20,6 @@ $ pip install karton-dashboard
 $ karton-dashboard run -h 127.0.0.1 -p 5000
 ```
 
+The `karton-dashboard` is just a wrapper on the `flask` program so you're free to provide it with arguments accepted by flask like `-h`, `--cert=path` and so on.
+
 ![Co-financed by the Connecting Europe Facility by of the European Union](https://www.cert.pl/wp-content/uploads/2019/02/en_horizontal_cef_logo-1.png)


### PR DESCRIPTION
It's missing the `run` subcommand, also added the optional `-hp` arguments to show that they are configurable