### PR TITLE
Fix karton metrics generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.1
 karton-core>=4.2.0,<5.0.0
 mistune==0.8.4
-prometheus_client==0.9.0
+prometheus_client==0.11.0


### PR DESCRIPTION
This PR aims to solve 2 issues regarding the generation of metrics in dashboard:

* `karton_replicas` gauge is never cleared - this causes dead/inactive binds to hang in the metrics forever
* `karton_tasks` suffers from a similar problem but it's masked by setting all labels to `0` - this was originally done to fix inconsistent graphs but this PR should solve it as well

