### PR TITLE
Added option to cancel pending tasks

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -263,6 +263,7 @@ def cancel_crashed_queue_tasks(queue_name):
     cancel_tasks(queue.crashed_tasks)
     return redirect(request.referrer)
 
+
 @app.route("/<queue_name>/cancel_pending", methods=["POST"])
 def cancel_pending_queue_tasks(queue_name):
     state = KartonState(karton.backend)
@@ -272,6 +273,7 @@ def cancel_pending_queue_tasks(queue_name):
 
     cancel_tasks(queue.pending_tasks)
     return redirect(request.referrer)
+
 
 @app.route("/restart_task/<task_id>/restart", methods=["POST"])
 def restart_task(task_id):

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -242,8 +242,8 @@ def get_queues_api():
     )
 
 
-@app.route("/<queue_name>/restart", methods=["POST"])
-def restart_queue_tasks(queue_name):
+@app.route("/<queue_name>/restart_crashed", methods=["POST"])
+def restart_crashed_queue_tasks(queue_name):
     state = KartonState(karton.backend)
     queue = state.queues.get(queue_name)
     if not queue:
@@ -253,8 +253,8 @@ def restart_queue_tasks(queue_name):
     return redirect(request.referrer)
 
 
-@app.route("/<queue_name>/cancel", methods=["POST"])
-def cancel_queue_tasks(queue_name):
+@app.route("/<queue_name>/cancel_crashed", methods=["POST"])
+def cancel_crashed_queue_tasks(queue_name):
     state = KartonState(karton.backend)
     queue = state.queues.get(queue_name)
     if not queue:
@@ -263,6 +263,15 @@ def cancel_queue_tasks(queue_name):
     cancel_tasks(queue.crashed_tasks)
     return redirect(request.referrer)
 
+@app.route("/<queue_name>/cancel_pending", methods=["POST"])
+def cancel_pending_queue_tasks(queue_name):
+    state = KartonState(karton.backend)
+    queue = state.queues.get(queue_name)
+    if not queue:
+        return jsonify({"error": "Queue doesn't exist"}), 404
+
+    cancel_tasks(queue.pending_tasks)
+    return redirect(request.referrer)
 
 @app.route("/restart_task/<task_id>/restart", methods=["POST"])
 def restart_task(task_id):

--- a/karton/dashboard/templates/crashed.html
+++ b/karton/dashboard/templates/crashed.html
@@ -4,11 +4,11 @@
 Crashed tasks
 {% if queue.crashed_tasks %}
   <div class="btn-group float-right">
-    <form action={{url_for("restart_queue_tasks", queue_name=name)}} method="POST">
+    <form action={{url_for("restart_crashed_queue_tasks", queue_name=name)}} method="POST">
       <button class="btn btn-sm btn-secondary mr-1" type="submit" value="Submit" title="restart all tasks">Restart all</button>
     </form>
     <div class="divider"></div>
-    <form action={{url_for("cancel_queue_tasks", queue_name=name)}} method="POST" id="cancelQueue">
+    <form action={{url_for("cancel_crashed_queue_tasks", queue_name=name)}} method="POST" id="cancelQueue">
       <button class="btn btn-sm btn-secondary" type="submit" form="cancelQueue" value="Submit" title="cancel all tasks">Cancel all</button>
     </form>
   </div>

--- a/karton/dashboard/templates/queue.html
+++ b/karton/dashboard/templates/queue.html
@@ -1,11 +1,20 @@
 {% extends 'queue_layout.html' %}
 {% block tasks %}
-<h4>Tasks</h4>
+<h4>Tasks
+  {% if queue.pending_tasks %}
+  <div class="btn-group float-right">
+    <form action={{url_for("cancel_pending_queue_tasks", queue_name=name)}} method="POST" id="cancelQueue">
+      <button class="btn btn-sm btn-secondary" type="submit" form="cancelQueue" value="Submit" title="cancel all tasks">Cancel all</button>
+    </form>  
+  </div> 
+{% endif %}
+</h4>
 <table class="table table-hover">
   <thead>
     <tr>
       <th scope="col">task</th>
       <th scope="col">headers</th>
+      <th scope="col">actions</th>
     </tr>
   </thead>
   <tbody>
@@ -31,6 +40,13 @@
         <span class="badge badge-secondary">{{hdrname}}:{{hdrval}}</span>
         {% endif %}
         {% endfor %}
+      </td>
+      <td>
+        <div class="btn-group">
+          <form action={{url_for("cancel_task", task_id=task.uid)}} method="POST">
+            <button class="btn btn-dark" type="submit" value="Submit" title="cancel task">✕</button>
+          </form>
+        </div>
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Added the option to cancel pending tasks using the same API used to cancel crashed tasks.
Also changed the naming so functionality is clear.

Tested locally for:
- Removing and restarting functionality for crashed tasks
- Removing pending tasks