### PR TITLE
Bump Flask from 1.1.1 to 2.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.0.3
 karton-core>=4.2.0,<5.0.0
 mistune==0.8.4
 prometheus_client==0.11.0


### PR DESCRIPTION
Fix breaking changes introduced by some Flask packages
```
$ karton-dashboard run
Traceback (most recent call last):
  File "/home/psrok1/karton-dashboard/venv/bin/karton-dashboard", line 5, in <module>
    from karton.dashboard import cli
  File "/home/psrok1/karton-dashboard/venv/lib/python3.9/site-packages/karton/dashboard/__init__.py", line 1, in <module>
    from .app import app
  File "/home/psrok1/karton-dashboard/venv/lib/python3.9/site-packages/karton/dashboard/app.py", line 13, in <module>
    from flask import (  # type: ignore
  File "/home/psrok1/karton-dashboard/venv/lib/python3.9/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/home/psrok1/karton-dashboard/venv/lib/python3.9/site-packages/jinja2/__init__.py)
```