### PR TITLE
initial graph

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -379,7 +379,7 @@ def get_graph():
 
 
 @app.route("/graph/generate", methods=["GET"])
-def get_graph_test():
+def generate_graph():
     state = KartonState(karton.backend)
     graph = KartonGraph(state)
     raw_graph = graph.generate_graph()

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -204,7 +204,7 @@ def varz():
         for task in queue.tasks:
             task_infos[(safe_name, task.priority, task.status)] += 1
 
-        # set the default of active queues to 0 to avoid gaps in graph
+        # set the default of active queues to 0 to avoid gaps in graphs
         for (priority, status) in product(TaskPriority, TaskState):
             karton_tasks.labels(safe_name, priority.value, status.value).set(0)
 

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -25,10 +25,13 @@ from karton.core.inspect import KartonAnalysis, KartonQueue, KartonState
 from karton.core.task import Task, TaskPriority, TaskState
 from prometheus_client import Gauge, generate_latest  # type: ignore
 
+from .graph.graph import KartonGraph
+
 logging.basicConfig(level=logging.INFO)
 
 app_path = Path(__file__).parent
 static_folder = app_path / "static"
+graph_folder = app_path / "graph"
 app = Flask(__name__, static_folder=None, template_folder=str(app_path / "templates"))
 
 karton = KartonBase(identity="karton.dashboard")
@@ -201,7 +204,7 @@ def varz():
         for task in queue.tasks:
             task_infos[(safe_name, task.priority, task.status)] += 1
 
-        # set the default of active queues to 0 to avoid gaps in graphs
+        # set the default of active queues to 0 to avoid gaps in graph
         for (priority, status) in product(TaskPriority, TaskState):
             karton_tasks.labels(safe_name, priority.value, status.value).set(0)
 
@@ -223,6 +226,11 @@ def varz():
 @app.route("/static/<path:path>", methods=["GET"])
 def static(path: str):
     return send_from_directory(static_folder, path)
+
+
+@app.route("/graph/<path:path>", methods=["GET"])
+def graph(path: str):
+    return send_from_directory(graph_folder, path)
 
 
 @app.route("/", methods=["GET"])
@@ -363,3 +371,12 @@ def get_analysis_api(root_id):
         return jsonify({"error": "Analysis doesn't exist"}), 404
 
     return jsonify(AnalysisView(analysis).to_dict())
+
+
+@app.route("/graph", methods=["GET"])
+def get_graph():
+    state = KartonState(karton.backend)
+    graph = KartonGraph(state)
+    raw_graph = graph.generate_graph()
+
+    return render_template("graph.html", raw_graph=raw_graph)

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -44,16 +44,12 @@ def restart_tasks(tasks: List[Task]) -> None:
     for task in tasks:
         # spawn a new task and mark the original one as finished
         producer.send_task(task.fork_task())
-        karton.backend.set_task_status(
-            task=task, status=TaskState.FINISHED, consumer=identity
-        )
+        karton.backend.set_task_status(task=task, status=TaskState.FINISHED)
 
 
 def cancel_tasks(tasks: List[Task]) -> None:
     for task in tasks:
-        karton.backend.set_task_status(
-            task=task, status=TaskState.FINISHED, consumer="karton.dashboard-cancel"
-        )
+        karton.backend.set_task_status(task=task, status=TaskState.FINISHED)
 
 
 class TaskView:

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -375,8 +375,13 @@ def get_analysis_api(root_id):
 
 @app.route("/graph", methods=["GET"])
 def get_graph():
+    return render_template("graph.html")
+
+
+@app.route("/graph/generate", methods=["GET"])
+def get_graph_test():
     state = KartonState(karton.backend)
     graph = KartonGraph(state)
     raw_graph = graph.generate_graph()
 
-    return render_template("graph.html", raw_graph=raw_graph)
+    return raw_graph

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -55,8 +55,10 @@ class KartonGraph:
         :type graph: networkx.DiGraph
         :param options: styling options, which consists of:
         \t`color`: a dictionary specifying RGBA
-        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`)
-        :type: Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
+        \t`size`: a function that takes a DiGraph and a node identity as
+        \t    an input and returns a size (`float`)
+        :type: |
+            Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
         """
         if not options:
             options = DEFAULT_OPTIONS

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -54,9 +54,10 @@ class KartonGraph:
         :param graph: a graph object
         :type graph: networkx.DiGraph
         :param options: styling options, which consists of:
-        \t`color`: a dictionary specifying RGBA
-        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`)
-        :type: Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
+        `color`: a dictionary specifying RGBA
+        `size`: a function that takes a DiGraph and a node
+        identity as an input and returns a size (`float`)
+        :type: Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]
         """
         if not options:
             options = DEFAULT_OPTIONS

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, cast
 
 from karton.core.inspect import KartonState
-from networkx import DiGraph, generate_gexf
-from networkx.readwrite.json_graph import adjacency_data, adjacency_graph
+from networkx import DiGraph, generate_gexf  # type: ignore
+from networkx.readwrite.json_graph import (  # type: ignore
+    adjacency_data,
+    adjacency_graph,
+)
 
 NODE_SIZE: Callable[
     [DiGraph, str], float
@@ -16,7 +19,7 @@ OPTIONS = ["color", "size"]
 
 class KartonNode:
     def __init__(
-        self, identity: str, metadata: dict[str, str], filters, outputs
+        self, identity: str, metadata: Dict[str, str], filters, outputs
     ) -> None:
         self.identity = identity
         self.metadata = metadata
@@ -45,9 +48,7 @@ class KartonGraph:
     def style_nodes(
         self,
         graph: DiGraph,
-        options: Optional[
-            Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]
-        ] = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Style the graph.
 
@@ -57,8 +58,7 @@ class KartonGraph:
         \t`color`: a dictionary specifying RGBA
         \t`size`: a function that takes a DiGraph and a node identity as
         \t    an input and returns a size (`float`)
-        :type: |
-            Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
+        :type: Optional[Dict[str, Any]]
         """
         if not options:
             options = DEFAULT_OPTIONS
@@ -70,7 +70,9 @@ class KartonGraph:
         for node in self.nodes:
             graph.nodes[node.identity]["viz"] = {
                 "color": options["color"],
-                "size": options["size"](graph, node.identity),
+                "size": cast(Callable[[DiGraph, str], float], options["size"])(
+                    graph, node.identity
+                ),
             }
 
             graph.nodes[node.identity]["version"] = node.metadata["version"]
@@ -102,9 +104,10 @@ class KartonGraph:
             values[outputs_object.identity]["outputs"] = outputs_object.outputs
 
         for identity in values.keys():
+            metadata = cast(Dict[str, str], values[identity]["metadata"])
             node = KartonNode(
                 identity=identity,
-                metadata=values[identity]["metadata"],
+                metadata=metadata,
                 filters=values[identity]["filters"],
                 outputs=values[identity]["outputs"],
             )

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional, Set, Union
+
+from karton.core.inspect import KartonState
+from networkx import DiGraph, generate_gexf
+from networkx.readwrite.json_graph import adjacency_data, adjacency_graph
+
+NODE_SIZE: Callable[
+    [DiGraph, str], float
+] = lambda graph, identity: 65 + 3.5 * graph.in_degree(identity)
+DEFAULT_OPTIONS = {"color": {"r": 51, "g": 153, "b": 243, "a": 0}, "size": NODE_SIZE}
+EMPTY_METADATA = {"version": "none", "info": "none"}
+OPTIONS = ["color", "size"]
+
+
+class KartonNode:
+    def __init__(
+        self, identity: str, metadata: dict[str, str], filters, outputs
+    ) -> None:
+        self.identity = identity
+        self.metadata = metadata
+        self.filters = filters
+        self.outputs = outputs
+
+    def filter_contained(self, filter: Dict[str, str], output: Dict[str, str]) -> bool:
+        return all(item in output.items() for item in filter.items())
+
+    def __contains__(self, other: KartonNode) -> bool:
+        if self.filters and other.outputs:
+            for filter in self.filters:
+                if any(
+                    self.filter_contained(filter, output) for output in other.outputs
+                ):
+                    return True
+        return False
+
+
+class KartonGraph:
+    def __init__(self, state: KartonState) -> None:
+        self.state: KartonState = state
+        self.nodes: List[KartonNode] = []
+        self.graph: Dict[str, Set[str]] = {}
+
+    def style_nodes(
+        self,
+        graph: DiGraph,
+        options: Optional[
+            Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]
+        ] = None,
+    ) -> None:
+        """Style the graph.
+
+        :param graph: a graph object
+        :type graph: networkx.DiGraph
+        :param options: styling options, which consists of:
+        \t`color`: a dictionary specifying RGBA
+        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`) 
+        :type: Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
+        """
+        if not options:
+            options = DEFAULT_OPTIONS
+
+        for option in OPTIONS:
+            if not options.get(option):
+                options[option] = DEFAULT_OPTIONS[option]
+
+        for node in self.nodes:
+            graph.nodes[node.identity]["viz"] = {
+                "color": options["color"],
+                "size": options["size"](graph, node.identity),
+            }
+
+            graph.nodes[node.identity]["version"] = node.metadata["version"]
+            graph.nodes[node.identity]["info"] = node.metadata["info"]
+
+    def build_nodes(self) -> None:
+        values = {}
+
+        for bind in self.state.backend.get_binds():
+            if bind.identity and bind.identity not in values:
+                values[bind.identity] = {
+                    "filters": None,
+                    "outputs": None,
+                    "metadata": EMPTY_METADATA,
+                }
+            values[bind.identity]["filters"] = bind.filters
+            values[bind.identity]["metadata"] = {
+                "version": bind.service_version if bind.service_version else "N/A",
+                "info": bind.info if bind.info else "N/A",
+            }
+
+        for outputs_object in self.state.backend.get_outputs():
+            if outputs_object.identity not in values:
+                values[outputs_object.identity] = {
+                    "filters": None,
+                    "outputs": None,
+                    "metadata": EMPTY_METADATA,
+                }
+            values[outputs_object.identity]["outputs"] = outputs_object.outputs
+
+        for identity in values.keys():
+            node = KartonNode(
+                identity=identity,
+                metadata=values[identity]["metadata"],
+                filters=values[identity]["filters"],
+                outputs=values[identity]["outputs"],
+            )
+
+            self.nodes.append(node)
+
+    def create_graph(self) -> None:
+        for node in self.nodes:
+            self.graph[node.identity] = set()
+
+        for node in self.nodes:
+            for other in self.nodes:
+                if other in node:
+                    self.graph[other.identity].add(node.identity)
+
+    def generate_graph(self) -> str:
+        self.build_nodes()
+        self.create_graph()
+
+        nx_graph = DiGraph(self.graph)
+        self.style_nodes(nx_graph)
+
+        adj_data = adjacency_data(nx_graph)
+        adj_graph = adjacency_graph(adj_data)
+        gexf_graph = ""
+        for line in generate_gexf(adj_graph):
+            gexf_graph += line
+
+        return gexf_graph

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -54,10 +54,9 @@ class KartonGraph:
         :param graph: a graph object
         :type graph: networkx.DiGraph
         :param options: styling options, which consists of:
-        `color`: a dictionary specifying RGBA
-        `size`: a function that takes a DiGraph and a node
-        identity as an input and returns a size (`float`)
-        :type: Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]
+        \t`color`: a dictionary specifying RGBA
+        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`) 
+        :type: Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
         """
         if not options:
             options = DEFAULT_OPTIONS

--- a/karton/dashboard/graph/graph.py
+++ b/karton/dashboard/graph/graph.py
@@ -55,7 +55,7 @@ class KartonGraph:
         :type graph: networkx.DiGraph
         :param options: styling options, which consists of:
         \t`color`: a dictionary specifying RGBA
-        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`) 
+        \t`size`: a function that takes a DiGraph and a node identity as an input and returns a size (`float`)
         :type: Optional[Dict[str, Union[Dict[str, int], Callable[[DiGraph, str], float]]]]
         """
         if not options:

--- a/karton/dashboard/static/graph/graph.js
+++ b/karton/dashboard/static/graph/graph.js
@@ -10,6 +10,29 @@ const attr = {
   info: "1",
 };
 
+const loadingOpts = {
+  text: 'loading graph, please wait',
+  color: '#3399F3',
+  textColor: '#000',
+  maskColor: 'rgba(255, 255, 255, 0.8)',
+  zlevel: 0,
+
+  // Font size. Available since `v4.8.0`.
+  fontSize: 12,
+  // Show an animated "spinner" or not. Available since `v4.8.0`.
+  showSpinner: true,
+  // Radius of the "spinner". Available since `v4.8.0`.
+  spinnerRadius: 10,
+  // Line width of the "spinner". Available since `v4.8.0`.
+  lineWidth: 5,
+  // Font thick weight. Available since `v5.0.1`.
+  fontWeight: 'normal',
+  // Font style. Available since `v5.0.1`.
+  fontStyle: 'normal',
+  // Font family. Available since `v5.0.1`.
+  fontFamily: 'sans-serif'
+};
+
 const arrayToObject = (array) =>
   array.reduce((obj, item) => {
     obj[item.id] = item;
@@ -21,8 +44,8 @@ window.onresize = function() {
 };
 
 option = null;
-myChart.showLoading();
-function show_graph(raw_graph) {
+myChart.showLoading('default', loadingOpts);
+$.get("/graph/generate", function(raw_graph) {
   myChart.hideLoading();
   myChart.resize();
 
@@ -135,7 +158,8 @@ function show_graph(raw_graph) {
   };
 
   myChart.setOption(option);
-}
+});
+
 if (option && typeof option === "object") {
   myChart.setOption(option, true);
 }

--- a/karton/dashboard/static/graph/graph.js
+++ b/karton/dashboard/static/graph/graph.js
@@ -66,7 +66,6 @@ $.get("/graph/generate", function(raw_graph) {
     legend: [],
     animation: true,
     animationDuration: 1500,
-    animationDelay: 1000,
     scaleLimit: {},
     animationEasingUpdate: "quinticInOut",
     dataZoom: [
@@ -107,7 +106,6 @@ $.get("/graph/generate", function(raw_graph) {
         data: graph.nodes,
         links: graph.links,
         roam: true,
-        focusNodeAdjacency: true,
         draggable: true,
         itemStyle: {
           normal: {
@@ -134,6 +132,7 @@ $.get("/graph/generate", function(raw_graph) {
           lineStyle: {
             width: 4,
           },
+          focus: 'adjacency',
         },
       },
     ],
@@ -197,17 +196,6 @@ myChart.on(
   (params) => {
     if (params.dataType === "node") {
       showInformation(params.data, params.color);
-      /* you can check params to look for what you want to pick */
-      myChart.dispatchAction({
-        /* HighLight type */
-        type: "focusNodeAdjacency",
-        /* OffLight type if you need */
-        // type: 'unfocusNodeAdjacency',
-        /* Positioning the series with seriesId/seriesIndex/seriesName */
-        seriesIndex: 0,
-        /* Positioning the node with dataIndex */
-        dataIndex: params.dataIndex,
-      });
     }
     params.event.stop();
   }

--- a/karton/dashboard/static/graph/graph.js
+++ b/karton/dashboard/static/graph/graph.js
@@ -11,26 +11,7 @@ const attr = {
 };
 
 const loadingOpts = {
-  text: 'loading graph, please wait',
-  color: '#3399F3',
-  textColor: '#000',
-  maskColor: 'rgba(255, 255, 255, 0.8)',
-  zlevel: 0,
-
-  // Font size. Available since `v4.8.0`.
-  fontSize: 12,
-  // Show an animated "spinner" or not. Available since `v4.8.0`.
-  showSpinner: true,
-  // Radius of the "spinner". Available since `v4.8.0`.
-  spinnerRadius: 10,
-  // Line width of the "spinner". Available since `v4.8.0`.
-  lineWidth: 5,
-  // Font thick weight. Available since `v5.0.1`.
-  fontWeight: 'normal',
-  // Font style. Available since `v5.0.1`.
-  fontStyle: 'normal',
-  // Font family. Available since `v5.0.1`.
-  fontFamily: 'sans-serif'
+  text: 'loading graph, please wait'
 };
 
 const arrayToObject = (array) =>

--- a/karton/dashboard/static/graph/graph.js
+++ b/karton/dashboard/static/graph/graph.js
@@ -1,0 +1,269 @@
+var dom = document.getElementById("graph-container");
+var myChart = echarts.init(dom);
+var app = {};
+var allNodes;
+var nodeData = {};
+var isLabelsHidden = false;
+
+const attr = {
+  version: "0",
+  info: "1",
+};
+
+const arrayToObject = (array) =>
+  array.reduce((obj, item) => {
+    obj[item.id] = item;
+    return obj;
+  }, {});
+
+window.onresize = function() {
+  myChart.resize();
+};
+
+option = null;
+myChart.showLoading();
+function show_graph(raw_graph) {
+  myChart.hideLoading();
+  myChart.resize();
+
+  var graph = echarts.dataTool.gexf.parse(raw_graph);
+  allNodes = arrayToObject(graph.nodes);
+
+  option = {
+    title: {
+      top: "bottom",
+      left: "right",
+    },
+    feature: {
+      magicType: {
+        type: ["line", "bar", "stack", "tiled"],
+      },
+    },
+    tooltip: {
+      formatter: function (params) {
+        if (params.dataType == "node") {
+          var nodeDescColor = "#3399F3";
+          var colorSpan =
+            '<span style="display:inline-block;margin-left:5px;border-radius:10px;width:9px;height:9px;background-color:' +
+            nodeDescColor +
+            '"></span>';
+          // is node
+          res = params.data.id + colorSpan;
+        } else if (params.dataType == "edge") {
+          // is edge
+          res =
+            allNodes[params.data.source].name +
+            " → " +
+            allNodes[params.data.target].name;
+        }
+        return res;
+      },
+    },
+    legend: [],
+    animation: true,
+    animationDuration: 1500,
+    scaleLimit: {},
+    animationEasingUpdate: "quinticInOut",
+    dataZoom: [
+      {
+        type: "inside",
+      },
+      {
+        type: "inside",
+      },
+    ],
+    xAxis: {
+      show: false,
+      scale: true,
+      silent: true,
+      type: "value",
+    },
+    yAxis: {
+      show: false,
+      scale: true,
+      silent: true,
+      type: "value",
+    },
+
+    series: [
+      {
+        name: "Karton map",
+        type: "graph",
+        layout: "force",
+        force: {
+          initLayout: "circular",
+          edgeLength: 1700,
+          repulsion: 150000,
+          gravity: 0.2,
+        },
+        zoom: 0.1,
+        edgeSymbol: ["circle", "arrow"],
+        edgeSymbolSize: [4, 9],
+        data: graph.nodes,
+        links: graph.links,
+        roam: true,
+        focusNodeAdjacency: true,
+        draggable: true,
+        itemStyle: {
+          normal: {
+            borderColor: "#fff",
+            borderWidth: 1,
+            shadowBlur: 10,
+            shadowColor: "rgba(0, 0, 0, 0.3)",
+          },
+        },
+        labelLayout: {
+          hideOverlap: true
+        },
+        label: {
+          position: "outside",
+          show: true,
+          formatter: "{b}",
+        },
+        lineStyle: {
+          color: "source",
+          curveness: 0.05,
+          width: 2,
+        },
+        emphasis: {
+          lineStyle: {
+            width: 4,
+          },
+        },
+      },
+    ],
+  };
+
+  myChart.setOption(option);
+}
+if (option && typeof option === "object") {
+  myChart.setOption(option, true);
+}
+
+myChart.on("dataZoom", function (params) {
+  var start = params.batch[0].start;
+  var end = params.batch[0].end;
+
+  if (
+    myChart.getOption().series[0].zoom <= 0.1 &&
+    myChart.getOption().series[0].zoom != 1 &&
+    !isLabelsHidden
+  ) {
+    myChart.setOption({
+      series: [
+        {
+          label: {
+            show: false,
+          },
+          force: {
+            friction: 0.1,
+          },
+        },
+      ],
+    });
+    isLabelsHidden = true;
+  } else if (
+    myChart.getOption().series[0].zoom > 0.1 &&
+    myChart.getOption().series[0].zoom != 1 &&
+    isLabelsHidden
+  ) {
+    myChart.setOption({
+      series: [
+        {
+          label: {
+            show: true,
+          },
+          force: {
+            friction: 0.1,
+          },
+        },
+      ],
+    });
+    isLabelsHidden = false;
+  }
+});
+
+myChart.on(
+  "click",
+  {
+    dataType: "node",
+  },
+  (params) => {
+    if (params.dataType === "node") {
+      showInformation(params.data, params.color);
+      /* you can check params to look for what you want to pick */
+      myChart.dispatchAction({
+        /* HighLight type */
+        type: "focusNodeAdjacency",
+        /* OffLight type if you need */
+        // type: 'unfocusNodeAdjacency',
+        /* Positioning the series with seriesId/seriesIndex/seriesName */
+        seriesIndex: 0,
+        /* Positioning the node with dataIndex */
+        dataIndex: params.dataIndex,
+      });
+    }
+    params.event.stop();
+  }
+);
+
+myChart.on("mousemove", (params) => {
+  if (params.dataType === "node") {
+    myChart.getZr().setCursorStyle("pointer");
+  } else {
+    myChart.getZr().setCursorStyle("default");
+  }
+});
+
+$("#graph-container").click(function () {
+  var $lefty = $(".side-menu");
+  $lefty.animate({
+    left: -300,
+  });
+
+  clearWindow();
+});
+
+function showInformation(node, color) {
+  clearWindow();
+
+  var $lefty = $(".side-menu");
+  $lefty.name = $lefty.find(".name");
+  $lefty.version = $lefty.find(".version");
+  $lefty.about = $lefty.find(".about");
+
+  $lefty.name.html("<b>Name: </b>" + node.name);
+
+  if (node.hasOwnProperty("attributes") && node.attributes != null) {
+    if (
+      attr.version in node.attributes &&
+      node.attributes[attr.version] != "none"
+    ) {
+      $lefty.version.html(
+        "<b>Version: </b>" + node.attributes[attr.version] + "<br/>"
+      );
+    }
+
+    if (attr.info in node.attributes && node.attributes[attr.info] != "none") {
+      spacesRemoved = node.attributes[attr.info].replace(/  +/g, "");
+      sanitized = DOMPurify.sanitize(spacesRemoved);
+      $lefty.about.html(marked.parse(sanitized));
+    }
+  }
+
+  $lefty.animate({
+    left: 0,
+  });
+}
+
+function clearWindow() {
+  var $lefty = $(".side-menu");
+
+  $lefty.name = $lefty.find(".name");
+  $lefty.version = $lefty.find(".version");
+  $lefty.about = $lefty.find(".about");
+
+  $lefty.name.html("");
+  $lefty.version.html("");
+  $lefty.about.html("");
+}

--- a/karton/dashboard/static/graph/graph.js
+++ b/karton/dashboard/static/graph/graph.js
@@ -66,6 +66,7 @@ $.get("/graph/generate", function(raw_graph) {
     legend: [],
     animation: true,
     animationDuration: 1500,
+    animationDelay: 1000,
     scaleLimit: {},
     animationEasingUpdate: "quinticInOut",
     dataZoom: [

--- a/karton/dashboard/static/graph/style.css
+++ b/karton/dashboard/static/graph/style.css
@@ -1,0 +1,33 @@
+body {
+  height: 100%;
+  overflow-y: hidden;
+}
+
+.side-menu {
+  font-size: 10pt;
+  line-height: 20px;
+  letter-spacing: 0.5px;
+  top: 65px;
+  padding: 10px;
+  position: absolute;
+  width: 230px;
+  color: #fff;
+  background-color: rgb(84, 124, 172);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  width: 320px;
+  left: -300px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.side-menu {
+  z-index: 1;
+}
+
+.page-content {
+  width: 100%;
+  max-width: 100%;
+}
+
+

--- a/karton/dashboard/templates/graph.html
+++ b/karton/dashboard/templates/graph.html
@@ -1,0 +1,42 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="bs-component">
+  <link type="text/css" rel="stylesheet" href="../static/graph/style.css" />
+  <script
+    type="text/javascript"
+    src="https://code.jquery.com/jquery-3.4.1.min.js"
+    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+    crossorigin="anonymous"></script>
+  <script
+    type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.3.2/echarts.min.js"></script>
+  <script
+    type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.3.2/extension/dataTool.min.js"></script>
+  <script
+    type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.15/marked.min.js"></script>
+  <script
+    type="text/javascript"
+    src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.6/purify.min.js"></script>
+
+  <div class="menu-hover">
+    <div class="side-menu">
+      <div class="info">
+        <div class="name"></div>
+        <div class="version"></div>
+        <div class="about"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="graph-container" style="height: 100vh;"></div>
+
+  <input type="hidden" id="graph_id" value="{{ raw_graph }}" />
+  <script src="../static/graph/graph.js"></script>
+  <script>
+    var raw_graph = document.querySelector("#graph_id").value;
+    show_graph(raw_graph);
+  </script>
+</div>
+{% endblock %}

--- a/karton/dashboard/templates/graph.html
+++ b/karton/dashboard/templates/graph.html
@@ -31,12 +31,6 @@
   </div>
 
   <div id="graph-container" style="height: 100vh;"></div>
-
-  <input type="hidden" id="graph_id" value="{{ raw_graph }}" />
   <script src="../static/graph/graph.js"></script>
-  <script>
-    var raw_graph = document.querySelector("#graph_id").value;
-    show_graph(raw_graph);
-  </script>
 </div>
 {% endblock %}

--- a/karton/dashboard/templates/layout.html
+++ b/karton/dashboard/templates/layout.html
@@ -16,6 +16,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/">home</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/graph">graph</a>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -33,7 +36,7 @@
         {% endwith %}
     </div>
 
-    <div class="container">
+    <div class="container page-content">
         {% block content %}
         {% endblock %}
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.0.3
 karton-core>=4.2.0,<5.0.0
 mistune==0.8.4
 prometheus_client==0.11.0
+networkx==2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
-karton-core>=4.2.0,<5.0.0
+karton-core>=4.4.0,<5.0.0
 mistune==0.8.4
 prometheus_client==0.11.0
 networkx==2.6.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ max-line-length = 88
 
 [mypy-apscheduler.*]
 ignore_missing_imports = True
+
+[mypy-networkx.*]
+ignore_missing_imports = True


### PR DESCRIPTION
# Karton graph visualization
![graph](https://user-images.githubusercontent.com/49753115/167376477-5508feb3-2cb1-4662-b26b-312148b0db42.gif)

## Introduction

This pull request adds a visualization of the kartons and the connections between them. A `graph` tab is added to the dashboard, and in it a directed graph. The graph is interactive, allowing zooming, moving the graph and moving the nodes. A click on a node shows info about it: its name, version (if available) and description (if available).

## In more details
### Stack used
* echarts.js - for the visualization
* marked.js - for description parsing
* DOMPurify - to sanitize the description
* networkx - for graph building in the backend, also used to generate a gexf of the graph

### Implementation details
A `/graph` route was added. When accessing it, the graph is built out of the binds and the [outputs](https://github.com/CERT-Polska/karton/commit/252a7f0be1533ff1eaffae3ba369457ba8e16939) in redis. For each karton we create a KartonNode object representing it, which then allows to see if one karton should have an edge to another (i.e., if the former karton's outputs are contained in the latter's binds).<br><br> After creating a graph object, we style it and provide size and color for each node. We then output it in gexf format. This gexf format graph is passed to the frontend. An echarts instance is created from the graph and displayed.

## Possible uses
A few possible uses for the graph might be:
* Discovery of faulty kartons; If a karton doesn't have any incoming or outgoing edges it might indicate of a problem
* Karton cycle detection; Is it okay that there's a loop between kartons?
* General karton system health checks

## Future work
* Currently the graph is calculated each time `/graph` is accessed, maybe some caching mechanism can be used
* ~Currently the backend it blocking when requesting `/graph` so a user needs to wait until they get the graph with a reasonably big karton system~ [changed](https://github.com/CERT-Polska/karton-dashboard/pull/56/commits/9fdd03752c19f1a9dafc9c434c7984662e2f93a1#diff-a741bda596437c254bd5ce381fe27687644f85dc31c15a58c79d9f2a492e2e94R48) so now a loading screen shows, but loading time should still be addressed
* Organize the graph in a better way, maybe as something that resembles a directed acyclic graph (although it is not acyclic)
* Implement highlighting of the cycles in the graph
* Implement highlighting all of the paths between two nodes in the graph