### PR TITLE
Update mistune to 2.0.4.

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -37,10 +37,11 @@ app = Flask(__name__, static_folder=None, template_folder=str(app_path / "templa
 karton = KartonBase(identity="karton.dashboard")
 
 markdown = mistune.create_markdown(
-    escape = True,
-    renderer = "html",
+    escape=True,
+    renderer="html",
     plugins=["url", "strikethrough", "footnotes", "table"],
 )
+
 
 def restart_tasks(tasks: List[Task]) -> None:
     identity = "karton.dashboard-retry"

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -36,6 +36,11 @@ app = Flask(__name__, static_folder=None, template_folder=str(app_path / "templa
 
 karton = KartonBase(identity="karton.dashboard")
 
+markdown = mistune.create_markdown(
+    escape = True,
+    renderer = "html",
+    plugins=["url", "strikethrough", "footnotes", "table"],
+)
 
 def restart_tasks(tasks: List[Task]) -> None:
     identity = "karton.dashboard-retry"
@@ -155,7 +160,7 @@ def pretty_delta(dt: datetime) -> str:
 def render_description(description) -> Optional[str]:
     if not description:
         return None
-    return mistune.markdown(textwrap.dedent(description))
+    return markdown(textwrap.dedent(description))
 
 
 @app.template_filter("render_timestamp")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.0.3
 karton-core>=5.0.0,<6.0.0
-mistune==0.8.4
+mistune==2.0.4
 prometheus_client==0.11.0
 networkx==2.6.3


### PR DESCRIPTION
I did this by comparing the API of [2.0.4](https://mistune.readthedocs.io/en/latest/api.html) and [0.8.4](https://mistune.readthedocs.io/en/v0.8.4/) as well as scanning the source code.

**Motivation**

The [nixpkgs](https://github.com/NixOS/nixpkgs) package manager usually only keeps the latest version of a Python package around. Right now, `karton-dashboard` is broken in nixpkgs, and this update will restore it. It also moves to a version of `mistune` that is actively developed.

**Testing**

The code changes necessary seem simple enough that I put together this PR, but I do not have `karton` set up (e.g. Redis and S3) so have not tested this. Any help in that quarter would be very welcome.