### PR TITLE
Refactor: correct graph package

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -25,7 +25,7 @@ from karton.core.inspect import KartonAnalysis, KartonQueue, KartonState
 from karton.core.task import Task, TaskPriority, TaskState
 from prometheus_client import Gauge, generate_latest  # type: ignore
 
-from .graph.graph import KartonGraph
+from .graph import KartonGraph
 
 logging.basicConfig(level=logging.INFO)
 

--- a/karton/dashboard/graph/__init__.py
+++ b/karton/dashboard/graph/__init__.py
@@ -1,0 +1,3 @@
+from .graph import KartonGraph
+
+__all__ = ["KartonGraph"]


### PR DESCRIPTION
`graph` package is exposed as namespace package instead of regular package.