### PR TITLE
Remove an unused (and potentially dangerous) route

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -231,11 +231,6 @@ def static(path: str):
     return send_from_directory(static_folder, path)
 
 
-@app.route("/graph/<path:path>", methods=["GET"])
-def graph(path: str):
-    return send_from_directory(graph_folder, path)
-
-
 @app.route("/", methods=["GET"])
 def get_queues():
     state = KartonState(karton.backend)


### PR DESCRIPTION
I believe this route is unused. Original intention was probably serving files in a `/static/graph` directory, but that's already handled by the `/static` route. Because of this, this can be safely removed. 