### PR TITLE
Restrict resource downloads to task payload resources

### DIFF
--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -9,10 +9,11 @@ from datetime import datetime
 from itertools import product
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import mistune  # type: ignore
 from flask import (
+    abort,
     Blueprint,
     Flask,
     jsonify,
@@ -81,6 +82,29 @@ markdown = mistune.create_markdown(
 def cancel_tasks(tasks: List[Task]) -> None:
     for task in tasks:
         karton.backend.set_task_status(task=task, status=TaskState.FINISHED)
+
+
+def iter_remote_resources(payload_value: Any) -> Iterator[RemoteResource]:
+    if isinstance(payload_value, RemoteResource):
+        yield payload_value
+    elif isinstance(payload_value, dict):
+        for value in payload_value.values():
+            yield from iter_remote_resources(value)
+    elif isinstance(payload_value, (list, tuple, set)):
+        for value in payload_value:
+            yield from iter_remote_resources(value)
+
+
+def find_task_resource(
+    task: Task,
+    bucket: str,
+    resource_uid: str,
+) -> Optional[RemoteResource]:
+    for payload in (task.payload, task.payload_persistent):
+        for resource in iter_remote_resources(payload):
+            if resource.bucket == bucket and resource.uid == resource_uid:
+                return resource
+    return None
 
 
 class ResourceView:
@@ -509,13 +533,24 @@ def generate_graph():
     return raw_graph
 
 
-@blueprint.route("/resource/download/<bucket>/<resource_uid>/<sha256>", methods=["GET"])
-def download_resource(bucket, resource_uid, sha256):
+@blueprint.route(
+    "/resource/download/<task_id>/<bucket>/<resource_uid>",
+    methods=["GET"],
+)
+def download_resource(task_id, bucket, resource_uid):
+    task = karton.backend.get_task(task_id)
+    if not task:
+        abort(404)
+
+    resource = find_task_resource(task, bucket, resource_uid)
+    if not resource:
+        abort(404)
+
     return send_file(
-        karton.backend.get_object(bucket, resource_uid),
+        karton.backend.get_object(resource.bucket, resource.uid),
         mimetype="application/octet-stream",
         as_attachment=True,
-        download_name=sha256,
+        download_name=resource.sha256 or resource.name,
     )
 
 

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -84,26 +84,14 @@ def cancel_tasks(tasks: List[Task]) -> None:
         karton.backend.set_task_status(task=task, status=TaskState.FINISHED)
 
 
-def iter_remote_resources(payload_value: Any) -> Iterator[RemoteResource]:
-    if isinstance(payload_value, RemoteResource):
-        yield payload_value
-    elif isinstance(payload_value, dict):
-        for value in payload_value.values():
-            yield from iter_remote_resources(value)
-    elif isinstance(payload_value, (list, tuple, set)):
-        for value in payload_value:
-            yield from iter_remote_resources(value)
-
-
 def find_task_resource(
     task: Task,
     bucket: str,
     resource_uid: str,
 ) -> Optional[RemoteResource]:
-    for payload in (task.payload, task.payload_persistent):
-        for resource in iter_remote_resources(payload):
-            if resource.bucket == bucket and resource.uid == resource_uid:
-                return resource
+    for resource in task.iterate_resources():
+         if resource.bucket == bucket and resource.uid == resource_uid:
+             return resource
     return None
 
 

--- a/karton/dashboard/app.py
+++ b/karton/dashboard/app.py
@@ -9,13 +9,13 @@ from datetime import datetime
 from itertools import product
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import mistune  # type: ignore
 from flask import (
-    abort,
     Blueprint,
     Flask,
+    abort,
     jsonify,
     make_response,
     redirect,
@@ -90,8 +90,12 @@ def find_task_resource(
     resource_uid: str,
 ) -> Optional[RemoteResource]:
     for resource in task.iterate_resources():
-         if resource.bucket == bucket and resource.uid == resource_uid:
-             return resource
+        if (
+            isinstance(resource, RemoteResource)
+            and resource.bucket == bucket
+            and resource.uid == resource_uid
+        ):
+            return resource
     return None
 
 

--- a/karton/dashboard/templates/task.html
+++ b/karton/dashboard/templates/task.html
@@ -68,7 +68,18 @@
   {% for payloads in [task.payload, task.payload_persistent] %}
     {% for pname, pcontent in payloads.items() %}
       {% if pcontent | parse_resource %}
-  <a class="btn btn-info" href="{{ url_for('dashboard.download_resource', bucket=pcontent.bucket, resource_uid=pcontent.uid, sha256=pcontent.sha256) }}">{{ pcontent.name }} ({{ pcontent.size | filesize }})</a>
+  {% set download_url = url_for(
+    'dashboard.download_resource',
+    task_id=task.uid,
+    bucket=pcontent.bucket,
+    resource_uid=pcontent.uid
+  ) %}
+  <a
+    class="btn btn-info"
+    href="{{ download_url }}"
+  >
+    {{ pcontent.name }} ({{ pcontent.size | filesize }})
+  </a>
       {% endif %}
     {% endfor %}
   {% endfor %}


### PR DESCRIPTION
## Summary

- Require resource downloads to reference an existing task
- Only allow downloading objects present in that task's payload or persistent payload
- Stop trusting the client-provided `sha256` URL segment as the download filename

## Security impact

Previously, the download endpoint accepted `bucket` and `resource_uid` directly from the URL and passed them to `karton.backend.get_object()`. Anyone who could reach the dashboard could construct a URL for another object.

The endpoint now returns 404 unless the referenced task exists and contains the requested `RemoteResource`.

## Checks

- `python3 -m compileall -q karton`
- `/tmp/karton-dashboard-venv/bin/python -m flake8 karton`
- `git diff --cached --check`
